### PR TITLE
Add dynamic budget allocation and remove CostTracker

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -25,3 +25,7 @@ llm_api_key = ""
 
 # paper searching engine
 #engine = "semanticscholar"
+
+# Budget allocation preference for pipeline modules: balanced, write-heavy,
+# think-heavy, or review-heavy
+#budget_preference = "balanced"

--- a/tests/test_scientist.py
+++ b/tests/test_scientist.py
@@ -47,5 +47,5 @@ def test_output_dir(tmp_path: Path) -> Path:
     return output_dir
 
 
-def test_mock() -> bool:
-    return True
+def test_mock() -> None:
+    assert True

--- a/tiny_scientist/__init__.py
+++ b/tiny_scientist/__init__.py
@@ -3,5 +3,6 @@ from .reviewer import Reviewer
 from .scientist import TinyScientist
 from .thinker import Thinker
 from .writer import Writer
+from .utils.checker import Checker
 
-__all__ = ["Coder", "Reviewer", "Thinker", "Writer", "TinyScientist"]
+__all__ = ["Coder", "Reviewer", "Thinker", "Writer", "TinyScientist", "Checker"]

--- a/tiny_scientist/coder.py
+++ b/tiny_scientist/coder.py
@@ -13,7 +13,7 @@ from aider.models import Model
 from rich import print
 
 from .configs import Config
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.llm import create_client, get_response_from_llm
 
 
@@ -28,7 +28,7 @@ class Coder:
         prompt_template_dir: Optional[str] = None,
         chat_history: Optional[str] = None,
         auto_install: bool = True,
-        cost_tracker: Optional[CostTracker] = None,
+        cost_tracker: Optional[Checker] = None,
     ):
         """Initialize the ExperimentCoder with configuration and Aider setup."""
         self.client, self.model = create_client(model)
@@ -38,7 +38,7 @@ class Coder:
         self.max_stderr_output = max_stderr_output
         self.auto_install = auto_install
         self.config = Config()
-        self.cost_tracker = cost_tracker or CostTracker()
+        self.cost_tracker = cost_tracker or Checker()
 
         # Load prompts
         self.prompts = self.config.prompt_template.coder_prompt

--- a/tiny_scientist/reviewer.py
+++ b/tiny_scientist/reviewer.py
@@ -5,7 +5,7 @@ from rich import print
 
 from .configs import Config
 from .tool import BaseTool, PaperSearchTool
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.error_handler import api_calling_error_exponential_backoff
 from .utils.input_formatter import InputFormatter
 from .utils.llm import (
@@ -24,7 +24,9 @@ class Reviewer:
         num_reflections: int = 2,
         temperature: float = 0.75,
         prompt_template_dir: Optional[str] = None,
-        cost_tracker: Optional[CostTracker] = None,
+        cost_tracker: Optional[Checker] = None,
+        pre_reflection_threshold: float = 0.5,
+        post_reflection_threshold: float = 0.8,
     ):
         self.tools = tools
         self.num_reviews = num_reviews
@@ -35,7 +37,9 @@ class Reviewer:
         self.searcher = PaperSearchTool()
         self._query_cache: Dict[str, List[Dict[str, Any]]] = {}
         self.last_related_works_string = ""
-        self.cost_tracker = cost_tracker or CostTracker()
+        self.cost_tracker = cost_tracker or Checker()
+        self.pre_reflection_threshold = pre_reflection_threshold
+        self.post_reflection_threshold = post_reflection_threshold
 
         self.prompts = self.config.prompt_template.reviewer_prompt
         self.prompts.neurips_form = self.prompts.neurips_form.format(
@@ -94,9 +98,35 @@ class Reviewer:
                 if "review" in tool_output:
                     current_review = tool_output["review"]["review"]
 
-            # Apply reflections
-            for j in range(self.num_reflections):
-                current_review = self.re_review(current_review)
+            # Apply reflections with dynamic budgeting
+            budget = self.cost_tracker.get_budget()
+            if (
+                budget is not None
+                and self.cost_tracker.get_total_cost() / budget >= self.pre_reflection_threshold
+            ):
+                print("[Reviewer] Skipping review reflections due to budget limit.")
+            else:
+                max_rounds = self.num_reflections
+                rounds_done = 0
+                per_round_cost = None
+                while rounds_done < max_rounds:
+                    start_cost = self.cost_tracker.get_total_cost()
+                    current_review = self.re_review(current_review)
+                    iteration_cost = self.cost_tracker.get_total_cost() - start_cost
+                    if per_round_cost is None:
+                        per_round_cost = max(iteration_cost, 1e-6)
+                        if budget is not None:
+                            allowed = budget * self.post_reflection_threshold
+                            remaining = allowed - self.cost_tracker.get_total_cost()
+                            additional = int(max(0.0, remaining) // per_round_cost)
+                            max_rounds = min(self.num_reflections, 1 + additional)
+                    rounds_done += 1
+                    if (
+                        budget is not None
+                        and self.cost_tracker.get_total_cost()
+                        >= budget * self.post_reflection_threshold
+                    ):
+                        break
 
             all_reviews.append(json.loads(current_review))
 

--- a/tiny_scientist/scientist.py
+++ b/tiny_scientist/scientist.py
@@ -1,11 +1,14 @@
+import os
 from typing import Any, Dict, List, Optional, Tuple, Union
+
+import toml
 
 from rich import print
 
 from .coder import Coder
 from .reviewer import Reviewer
 from .thinker import Thinker
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.input_formatter import InputFormatter
 from .writer import Writer
 
@@ -18,6 +21,7 @@ class TinyScientist:
         template: str = "acl",
         prompt_template_dir: Optional[str] = None,
         budget: Optional[float] = None,
+        budget_preference: Optional[str] = None,
     ):
         self.model = model
         self.output_dir = output_dir
@@ -27,9 +31,27 @@ class TinyScientist:
 
         self.cost = 0.0
 
-        # Naive budget split
-        modules = ["thinker", "coder", "writer", "reviewer"]
-        per_module_budget = budget / len(modules) if budget else None
+        if budget_preference is None:
+            config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.toml")
+            if os.path.exists(config_path):
+                cfg = toml.load(config_path)
+                budget_preference = cfg.get("core", {}).get("budget_preference", "balanced")
+            else:
+                budget_preference = "balanced"
+
+        weights = {
+            "balanced": {"thinker": 0.3, "writer": 0.3, "reviewer": 0.3, "coder": 0.1},
+            "write-heavy": {"thinker": 0.2, "writer": 0.5, "reviewer": 0.2, "coder": 0.1},
+            "think-heavy": {"thinker": 0.5, "writer": 0.2, "reviewer": 0.2, "coder": 0.1},
+            "review-heavy": {"thinker": 0.2, "writer": 0.2, "reviewer": 0.5, "coder": 0.1},
+        }
+        if budget_preference not in weights:
+            raise ValueError(f"Unknown budget preference: {budget_preference}")
+
+        allocation = {
+            k: (budget * w if budget is not None else None)
+            for k, w in weights[budget_preference].items()
+        }
 
         self.thinker = Thinker(
             model=model,
@@ -40,7 +62,7 @@ class TinyScientist:
             search_papers=True,
             generate_exp_plan=True,
             enable_ethical_defense=False,
-            cost_tracker=CostTracker(budget=per_module_budget),
+            cost_tracker=Checker(budget=allocation.get("thinker")),
         )
 
         self.coder = Coder(
@@ -49,7 +71,7 @@ class TinyScientist:
             prompt_template_dir=prompt_template_dir,
             max_iters=4,
             max_runs=3,
-            cost_tracker=CostTracker(budget=per_module_budget),
+            cost_tracker=Checker(budget=allocation.get("coder")),
         )
 
         self.writer = Writer(
@@ -57,14 +79,14 @@ class TinyScientist:
             output_dir=output_dir,
             prompt_template_dir=prompt_template_dir,
             template=template,
-            cost_tracker=CostTracker(budget=per_module_budget),
+            cost_tracker=Checker(budget=allocation.get("writer")),
         )
 
         self.reviewer = Reviewer(
             model=model,
             prompt_template_dir=prompt_template_dir,
             tools=[],
-            cost_tracker=CostTracker(budget=per_module_budget),
+            cost_tracker=Checker(budget=allocation.get("reviewer")),
         )
 
     def think(

--- a/tiny_scientist/thinker.py
+++ b/tiny_scientist/thinker.py
@@ -6,7 +6,7 @@ from rich import print
 
 from .configs import Config
 from .tool import PaperSearchTool
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.error_handler import api_calling_error_exponential_backoff
 from .utils.llm import (
     create_client,
@@ -26,8 +26,10 @@ class Thinker:
         output_dir: str = "",
         temperature: float = 0.75,
         prompt_template_dir: Optional[str] = None,
-        cost_tracker: Optional[CostTracker] = None,
+        cost_tracker: Optional[Checker] = None,
         enable_ethical_defense: bool = False,
+        pre_reflection_threshold: float = 0.5,
+        post_reflection_threshold: float = 0.8,
     ):
         self.tools = tools
         self.iter_num = iter_num
@@ -67,7 +69,9 @@ Be critical and realistic in your assessments."""
         3. Novelty: How original is the idea compared to existing work?
         4. Feasibility: How practical is implementation within reasonable resource constraints?
         5. Impact: What is the potential impact of this research on the field and broader applications?"""
-        self.cost_tracker = cost_tracker or CostTracker()
+        self.cost_tracker = cost_tracker or Checker()
+        self.pre_reflection_threshold = pre_reflection_threshold
+        self.post_reflection_threshold = post_reflection_threshold
 
         self.enable_ethical_defense = enable_ethical_defense
 
@@ -362,9 +366,26 @@ Be critical and realistic in your assessments."""
     def _refine_idea(self, idea_json: str) -> str:
         current_idea_json = idea_json
 
-        for j in range(self.iter_num):
-            print(f"Refining idea {j + 1}th time out of {self.iter_num} times.")
+        # Skip reflections entirely if budget usage is already high
+        budget = self.cost_tracker.get_budget()
+        if (
+            budget is not None
+            and self.cost_tracker.get_total_cost() / budget >= self.pre_reflection_threshold
+        ):
+            print("[Thinker] Skipping idea reflections due to budget limit.")
+            self.cost_tracker.report()
+            return current_idea_json
 
+        max_rounds = self.iter_num
+        rounds_done = 0
+        per_round_cost = None
+
+        while rounds_done < max_rounds:
+            print(
+                f"Refining idea {rounds_done + 1}th time out of {max_rounds} times."
+            )
+
+            start_cost = self.cost_tracker.get_total_cost()
             current_idea_dict = json.loads(current_idea_json)
             for tool in self.tools:
                 tool_input = json.dumps(current_idea_dict)
@@ -372,7 +393,23 @@ Be critical and realistic in your assessments."""
                 current_idea_dict.update(info)
             current_idea_json = json.dumps(current_idea_dict)
 
-            current_idea_json = self.rethink(current_idea_json, current_round=j + 1)
+            current_idea_json = self.rethink(current_idea_json, current_round=rounds_done + 1)
+
+            iteration_cost = self.cost_tracker.get_total_cost() - start_cost
+            if per_round_cost is None:
+                per_round_cost = max(iteration_cost, 1e-6)
+                if budget is not None:
+                    allowed = budget * self.post_reflection_threshold
+                    remaining = allowed - self.cost_tracker.get_total_cost()
+                    additional = int(max(0.0, remaining) // per_round_cost)
+                    max_rounds = min(self.iter_num, 1 + additional)
+
+            rounds_done += 1
+            if (
+                budget is not None
+                and self.cost_tracker.get_total_cost() >= budget * self.post_reflection_threshold
+            ):
+                break
 
         self.cost_tracker.report()
         return current_idea_json

--- a/tiny_scientist/tool.py
+++ b/tiny_scientist/tool.py
@@ -12,7 +12,7 @@ import toml
 from rich import print
 
 from .configs import Config
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.error_handler import api_calling_error_exponential_backoff
 from .utils.llm import create_client, get_response_from_llm
 
@@ -22,8 +22,8 @@ config = toml.load(config_path) if os.path.exists(config_path) else {"core": {}}
 
 
 class BaseTool(abc.ABC):
-    def __init__(self, cost_tracker: Optional[CostTracker] = None) -> None:
-        self.cost_tracker = cost_tracker or CostTracker()
+    def __init__(self, cost_tracker: Optional[Checker] = None) -> None:
+        self.cost_tracker = cost_tracker or Checker()
         self.github_token = config["core"].get("github_token", None)
 
     @abc.abstractmethod

--- a/tiny_scientist/utils/checker.py
+++ b/tiny_scientist/utils/checker.py
@@ -6,10 +6,12 @@ from .pricing import calculate_pricing
 
 
 class BudgetExceededError(Exception):
-    pass
+    """Raised when a call would exceed the configured budget."""
 
 
-class CostTracker:
+class Checker:
+    """Track API usage cost and enforce a spending budget."""
+
     def __init__(self, budget: Optional[float] = None) -> None:
         self.total_cost = 0.0
         self.per_task_cost: Dict[str, float] = {}
@@ -58,3 +60,13 @@ class CostTracker:
 
     def get_task_cost(self, task_name: str) -> float:
         return self.per_task_cost.get(task_name, 0.0)
+
+    def get_remaining_budget(self) -> Optional[float]:
+        """Return remaining budget if a limit is set."""
+        if self.budget is None:
+            return None
+        return self.budget - self.total_cost
+
+    def get_budget(self) -> Optional[float]:
+        """Return the configured budget."""
+        return self.budget

--- a/tiny_scientist/utils/llm.py
+++ b/tiny_scientist/utils/llm.py
@@ -9,7 +9,7 @@ import openai
 import toml
 from google.generativeai.types import GenerationConfig
 
-from tiny_scientist.utils.cost_tracker import CostTracker
+from tiny_scientist.utils.checker import Checker
 
 # Load config
 config_path = os.path.join(
@@ -84,7 +84,7 @@ def get_batch_responses_from_llm(
     msg_history: Any = None,
     temperature: float = 0.75,
     n_responses: int = 1,
-    cost_tracker: Optional[CostTracker] = None,
+    cost_tracker: Optional[Checker] = None,
     task_name: Optional[str] = None,
 ) -> Tuple[List[str], List[List[Dict[str, str]]]]:
     if msg_history is None:
@@ -214,7 +214,7 @@ def get_response_from_llm(
     print_debug: bool = False,
     msg_history: Any = None,
     temperature: float = 0.75,
-    cost_tracker: Optional[CostTracker] = None,
+    cost_tracker: Optional[Checker] = None,
     task_name: Optional[str] = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
     if msg_history is None:
@@ -442,7 +442,7 @@ def get_batch_responses_from_llm_with_tools(
     msg_history: Optional[List[Dict[str, str]]] = None,
     temperature: float = 0.75,
     n_responses: int = 1,
-    cost_tracker: Optional[CostTracker] = None,
+    cost_tracker: Optional[Checker] = None,
     task_name: Optional[str] = None,
 ) -> Tuple[List[Union[str, Dict[str, Any]]], List[List[Dict[str, str]]]]:
     """

--- a/tiny_scientist/writer.py
+++ b/tiny_scientist/writer.py
@@ -12,7 +12,7 @@ from rich import print
 
 from .configs import Config
 from .tool import BaseTool, DrawerTool, PaperSearchTool
-from .utils.cost_tracker import CostTracker
+from .utils.checker import Checker
 from .utils.llm import (
     create_client,
     extract_json_between_markers,
@@ -33,7 +33,7 @@ class Writer:
         template: str,
         temperature: float = 0.75,
         prompt_template_dir: Optional[str] = None,
-        cost_tracker: Optional[CostTracker] = None,
+        cost_tracker: Optional[Checker] = None,
         s2_api_key: Optional[str] = None,
     ) -> None:
         self.client, self.model = create_client(model)
@@ -50,7 +50,7 @@ class Writer:
             self.formatter = ICLROutputFormatter(model=self.model, client=self.client)
 
         self.prompts = self.config.prompt_template.writer_prompt
-        self.cost_tracker = cost_tracker or CostTracker()
+        self.cost_tracker = cost_tracker or Checker()
 
         with resources.files("tiny_scientist.fewshot_sample").joinpath(
             "automated_relational.txt"


### PR DESCRIPTION
## Summary
- drop `CostTracker` shim entirely
- support budget preference in config with balanced/write/think/review options
- allocate per-module budgets accordingly in `TinyScientist`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d907b32a88324b33b5d68b07b2f9c